### PR TITLE
If no network is checked, only update once

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -113,7 +113,12 @@ Item {
     }
 
     function getTriggerInterval() {
-        if (numCheckedNets < 1)     return 0
-        else                        return updateInterval
+        if (numCheckedNets < 1) {
+            // If no network is checked, only update once
+            sysMonitor.updateUi()
+            return 0
+        } else {
+            return updateInterval
+        }
     } 
 }


### PR DESCRIPTION
When no network is checked, the network speed should be displayed as 0. 